### PR TITLE
✨ Improve dev workflow by caching `pip install` with Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,20 @@ docker run --rm -p 8888:8888 -e JUPYTER_ENABLE_LAB=yes -v "$PWD":/home/jovyan/wo
 ```
 
 In your web browser, go to the URL shown in the output.
+
+Or if you want to cache installation of python depenencies,
+you can build docker image once with dependencies installed:
+
+```
+cd notebooks
+make build  # will use Makefile "build" target
+```
+
+and keep using it:
+
+```
+cd notebooks
+make run # will use Makefile's "run" target
+```
+
+In your web browser, go to the URL shown in the output.

--- a/notebooks/Dockerfile
+++ b/notebooks/Dockerfile
@@ -1,0 +1,8 @@
+FROM jupyter/datascience-notebook:python-3.9
+
+# Install langchain[llms] and python-dotenv
+RUN pip install langchain[llms] \
+    && pip install python-dotenv
+
+# Set the working directory
+WORKDIR /home/jovyan/work

--- a/notebooks/Makefile
+++ b/notebooks/Makefile
@@ -1,0 +1,8 @@
+.PHONY: build run
+
+build:
+	docker build -t cristobalcl_img .
+
+run:
+	docker run --rm -p 8888:8888 -e JUPYTER_ENABLE_LAB=yes -v "$$PWD":/home/jovyan/work cristobalcl_img
+


### PR DESCRIPTION
This commit introduces Docker usage to build an image that caches the installation of Python dependencies, preventing the need for repeated downloads and installations in subsequent runs. This enhances the development workflow by saving time and bandwidth.